### PR TITLE
Extend PH curve fitting with quaternionic G² handling

### DIFF
--- a/PH-Curve.Test/CubicPHCurve3DFitterTests.cs
+++ b/PH-Curve.Test/CubicPHCurve3DFitterTests.cs
@@ -12,9 +12,9 @@ namespace PH_Curve.Test
         {
             var cps = new[]
             {
-                new CubicPHCurve3DFitter.ControlPointEx{Position=new Vector3(0,0,0), Time=0f, Normal=Vector3.UnitZ},
-                new CubicPHCurve3DFitter.ControlPointEx{Position=new Vector3(1,1,0), Time=0.5f, Normal=Vector3.UnitZ},
-                new CubicPHCurve3DFitter.ControlPointEx{Position=new Vector3(2,0,0), Time=1f, Normal=Vector3.UnitZ}
+                new CubicPHCurve3DFitter.ControlPointEx{Position=new Vector3(0,0,0), Time=0f, Normal=Vector3.UnitZ, Curvature=0f},
+                new CubicPHCurve3DFitter.ControlPointEx{Position=new Vector3(1,1,0), Time=0.5f, Normal=Vector3.UnitZ, Curvature=0f},
+                new CubicPHCurve3DFitter.ControlPointEx{Position=new Vector3(2,0,0), Time=1f, Normal=Vector3.UnitZ, Curvature=0f}
             };
 
             bool ok = CubicPHCurve3DFitter.FitSingleSegmentPH3D(cps, out var curve, out var posErr, out var normErr, out var T0, out var T1);

--- a/PH-Curve/CubicPHCurve3D.cs
+++ b/PH-Curve/CubicPHCurve3D.cs
@@ -8,19 +8,62 @@ namespace CubicPHCurve
     {
         // Polynomial coefficients for r'(t) = A + B t + C t^2 + D t^3 + E t^4
         private readonly Vector3 A, B, C, D, E;
+        private static readonly Quaternion BasisI = new(0f, 1f, 0f, 0f);
 
         /// <summary>
-        /// Hermite control point with position and tangent
+        /// Hermite control point used to construct the curve.
         /// </summary>
         public struct ControlPoint
         {
+            /// <summary>Position of the point.</summary>
             public Vector3 Position;
+            /// <summary>Tangent (derivative) at the point.</summary>
             public Vector3 Tangent;
-            public ControlPoint(Vector3 pos, Vector3 tan)
+            /// <summary>Optional normal at the point.</summary>
+            public Vector3 Normal;
+            /// <summary>Optional curvature value.</summary>
+            public float Curvature;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ControlPoint"/> struct.
+            /// </summary>
+            /// <param name="pos">Point position.</param>
+            /// <param name="tan">Tangent vector.</param>
+            /// <param name="normal">Optional normal vector.</param>
+            /// <param name="curvature">Optional curvature.</param>
+            public ControlPoint(Vector3 pos, Vector3 tan, Vector3 normal = default, float curvature = 0f)
             {
                 Position = pos;
                 Tangent = tan;
+                Normal = normal;
+                Curvature = curvature;
             }
+        }
+
+        private static Vector3 V(Quaternion q) => new(q.X, q.Y, q.Z);
+
+        private static Quaternion Scale(Quaternion q, float s) => new(q.X * s, q.Y * s, q.Z * s, q.W * s);
+
+        private static Quaternion FrameQuaternion(Vector3 tangent, Vector3 normal)
+        {
+            Vector3 T = Vector3.Normalize(tangent);
+            Vector3 N = Vector3.Normalize(normal);
+            Vector3 B = Vector3.Normalize(Vector3.Cross(T, N));
+            var rot = new Matrix4x4(
+                T.X, T.Y, T.Z, 0f,
+                N.X, N.Y, N.Z, 0f,
+                B.X, B.Y, B.Z, 0f,
+                0f, 0f, 0f, 1f);
+            return Quaternion.CreateFromRotationMatrix(rot);
+        }
+
+        private static Quaternion QuaternionFromDerivative(Vector3 tangent, Vector3 normal)
+        {
+            float len = tangent.Length();
+            if (len < 1e-8f)
+                return Quaternion.Identity;
+            Quaternion rot = FrameQuaternion(tangent, normal == Vector3.Zero ? Vector3.UnitY : normal);
+            return Scale(rot, MathF.Sqrt(len));
         }
 
         /// <summary>
@@ -29,7 +72,7 @@ namespace CubicPHCurve
         /// </summary>
         public static CubicPHCurve3D FromControlPoints(ControlPoint cp0, ControlPoint cp1)
         {
-            return ComputePolynomialCoefficients(cp0.Position, cp0.Tangent, cp1.Position, cp1.Tangent);
+            return ComputePolynomialCoefficientsQuaternion(cp0, cp1);
         }
 
         /// <summary>
@@ -45,38 +88,69 @@ namespace CubicPHCurve
         }
 
         /// <summary>
-        /// Compute PH segment coefficients directly from Hermite data
-        /// via a 4×4 linear solve enforcing Hermite and PH constraints.
+        /// Compute PH segment coefficients via quaternionic formulation taking
+        /// G² constraints (tangent, normal and curvature) at both end points
+        /// into account.
         /// </summary>
-        private static CubicPHCurve3D ComputePolynomialCoefficients(
-            Vector3 p0, Vector3 t0,
-            Vector3 p1, Vector3 t1)
+        private static CubicPHCurve3D ComputePolynomialCoefficientsQuaternion(ControlPoint c0, ControlPoint c1)
         {
-            // A = r'(0)
-            Vector3 A = t0;
-            // S = remaining displacement
-            Vector3 S = p1 - p0 - A;
-            // Build 4x4 float matrix enforcing PH-Hermite constraints
-            var M = Matrix<float>.Build.DenseOfArray(new float[,] {
-                {1f,    1f,    1f,    1f   },   // B+C+D+E = t1 - A
-                {0.5f, 1f/3f, 0.25f, 0.2f },   // 1/2 B +1/3 C+1/4 D+1/5 E = S
-                // PH constraint 1: A·C + 0.5 B·B = 0 -> C coefficient
-                {0f,    1f,    0f,    0f  },
-                // PH constraint 2: B·D + C·C + A·E = 0 -> D coefficient
-                {0f,    0f,    1f,    0f  }
+            Vector3 t0 = c0.Tangent;
+            Vector3 t1 = c1.Tangent;
+
+            Quaternion q0 = QuaternionFromDerivative(t0, c0.Normal);
+            Quaternion q1 = QuaternionFromDerivative(t1, c1.Normal);
+
+            Vector3 k0Vec = c0.Curvature * t0.LengthSquared() * (c0.Normal == Vector3.Zero ? Vector3.UnitY : Vector3.Normalize(c0.Normal));
+            Vector3 k1Vec = c1.Curvature * t1.LengthSquared() * (c1.Normal == Vector3.Zero ? Vector3.UnitY : Vector3.Normalize(c1.Normal));
+
+            Quaternion[] basis = new[]
+            {
+                new Quaternion(1f,0f,0f,0f),
+                new Quaternion(0f,1f,0f,0f),
+                new Quaternion(0f,0f,1f,0f),
+                new Quaternion(0f,0f,0f,1f)
+            };
+
+            var M = Matrix<float>.Build.Dense(6,4);
+            for (int j=0;j<4;++j)
+            {
+                Quaternion e = basis[j];
+                Vector3 col0 = V(e*BasisI*Quaternion.Conjugate(q0) + q0*BasisI*Quaternion.Conjugate(e));
+                Vector3 col1 = V(-e*BasisI*Quaternion.Conjugate(q1) - q1*BasisI*Quaternion.Conjugate(e));
+                M[0,j] = col0.X; M[1,j]=col0.Y; M[2,j]=col0.Z;
+                M[3,j] = col1.X; M[4,j]=col1.Y; M[5,j]=col1.Z;
+            }
+
+            Quaternion K = 2f * q1 - 2f * q0;
+            Vector3 const1 = V(K*BasisI*Quaternion.Conjugate(q1) + q1*BasisI*Quaternion.Conjugate(K));
+
+            var b = Vector<float>.Build.Dense(new float[]
+            {
+                k0Vec.X*0.5f, k0Vec.Y*0.5f, k0Vec.Z*0.5f,
+                k1Vec.X*0.5f - const1.X, k1Vec.Y*0.5f - const1.Y, k1Vec.Z*0.5f - const1.Z
             });
-            // RHS float vectors
-            var rhsX = MathNet.Numerics.LinearAlgebra.Vector<float>.Build.DenseOfArray(new float[] { t1.X - A.X, S.X, 0f, 0f });
-            var rhsY = MathNet.Numerics.LinearAlgebra.Vector<float>.Build.DenseOfArray(new float[] { t1.Y - A.Y, S.Y, 0f, 0f });
-            var rhsZ = MathNet.Numerics.LinearAlgebra.Vector<float>.Build.DenseOfArray(new float[] { t1.Z - A.Z, S.Z, 0f, 0f });
-            var solX = M.Solve(rhsX);
-            var solY = M.Solve(rhsY);
-            var solZ = M.Solve(rhsZ);
-            Vector3 B = new Vector3(solX[0], solY[0], solZ[0]);
-            Vector3 C = new Vector3(solX[1], solY[1], solZ[1]);
-            Vector3 D = new Vector3(solX[2], solY[2], solZ[2]);
-            Vector3 E = new Vector3(solX[3], solY[3], solZ[3]);
-            return new CubicPHCurve3D(A, B, C, D, E);
+
+            Vector<float> x = M.Svd(true).Solve(b);
+
+            Quaternion qd1 = new(x[0], x[1], x[2], x[3]);
+            Quaternion qd2 = q1 - q0 - qd1;
+
+            var coeffs = DerivativeCoefficientsFromQuaternions(q0, qd1, qd2);
+            return new CubicPHCurve3D(coeffs.A, coeffs.B, coeffs.C, coeffs.D, coeffs.E);
+        }
+
+        private static (Vector3 A, Vector3 B, Vector3 C, Vector3 D, Vector3 E) DerivativeCoefficientsFromQuaternions(Quaternion q0, Quaternion q1, Quaternion q2)
+        {
+            Quaternion c0 = Quaternion.Conjugate(q0);
+            Quaternion c1 = Quaternion.Conjugate(q1);
+            Quaternion c2 = Quaternion.Conjugate(q2);
+
+            Vector3 A = V(q0*BasisI*c0);
+            Vector3 B = V(q0*BasisI*c1 + q1*BasisI*c0);
+            Vector3 C = V(q0*BasisI*c2 + q1*BasisI*c1 + q2*BasisI*c0);
+            Vector3 D = V(q1*BasisI*c2 + q2*BasisI*c1);
+            Vector3 E = V(q2*BasisI*c2);
+            return (A,B,C,D,E);
         }
 
         /// <summary>Hodograph r'(t)</summary> r'(t)</summary>

--- a/PH-Curve/CubicPHCurve3DFitter.cs
+++ b/PH-Curve/CubicPHCurve3DFitter.cs
@@ -8,11 +8,19 @@ namespace CubicPHCurve
 {
     public class CubicPHCurve3DFitter
     {
+        /// <summary>
+        /// Control point used for fitting including time and normal information.
+        /// </summary>
         public struct ControlPointEx
         {
+            /// <summary>Spatial position of the point.</summary>
             public Vector3 Position;
+            /// <summary>Absolute time parameter of the point.</summary>
             public float Time;
+            /// <summary>Normal vector at the point.</summary>
             public Vector3 Normal;
+            /// <summary>Curvature at the point.</summary>
+            public float Curvature;
         }
 
         public static bool FitSingleSegmentPH3D(
@@ -42,14 +50,15 @@ namespace CubicPHCurve
             int N = cps.Length;
             Vector3[] posS = cps.Select(cp => cp.Position).ToArray();
             Vector3[] nrmS = cps.Select(cp => cp.Normal).ToArray();
+            float[] curvS = cps.Select(cp => cp.Curvature).ToArray();
 
             double Error(MathNet.Numerics.LinearAlgebra.Vector<double> vars)
             {
                 float m0 = (float)vars[0];
                 float m1 = (float)vars[1];
 
-                var cpH0 = new CubicPHCurve3D.ControlPoint(p0, u0 * m0);
-                var cpH1 = new CubicPHCurve3D.ControlPoint(p1, u1 * m1);
+                var cpH0 = new CubicPHCurve3D.ControlPoint(p0, u0 * m0, cps[0].Normal, cps[0].Curvature);
+                var cpH1 = new CubicPHCurve3D.ControlPoint(p1, u1 * m1, cps[^1].Normal, cps[^1].Curvature);
                 var seg = CubicPHCurve3D.FromControlPoints(cpH0, cpH1);
 
                 double sum = 0.0;
@@ -75,8 +84,8 @@ namespace CubicPHCurve
             float m0_fit = (float)sol[0];
             float m1_fit = (float)sol[1];
 
-            var finalCP0 = new CubicPHCurve3D.ControlPoint(p0, u0 * m0_fit);
-            var finalCP1 = new CubicPHCurve3D.ControlPoint(p1, u1 * m1_fit);
+            var finalCP0 = new CubicPHCurve3D.ControlPoint(p0, u0 * m0_fit, cps[0].Normal, cps[0].Curvature);
+            var finalCP1 = new CubicPHCurve3D.ControlPoint(p1, u1 * m1_fit, cps[^1].Normal, cps[^1].Curvature);
             fitted = CubicPHCurve3D.FromControlPoints(finalCP0, finalCP1);
 
             double sumPos2 = 0, sumNorm2 = 0;


### PR DESCRIPTION
## Summary
- introduce quaternion helper methods in `CubicPHCurve3D`
- compute PH coefficients via quaternionic formulation with G² constraints

## Testing
- `dotnet test PH-Curve.sln --no-build --logger:"console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_684b10207618832ab127ef3fb25b5536