### PR TITLE
Sync with upstream and add tangent fitting test

### DIFF
--- a/PH-Curve.Test/CubicPHCurve3DFitterTests.cs
+++ b/PH-Curve.Test/CubicPHCurve3DFitterTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Numerics;
 using CubicPHCurve;
+using MathNet.Numerics.Optimization;
 
 namespace PH_Curve.Test
 {
@@ -30,6 +31,110 @@ namespace PH_Curve.Test
             Vector3 vel = PHCurveTimeUtils.VelocityAtTime(curve, midT, T0, T1);
             Vector3 deriv = curve.Derivative(0.5f) / (T1 - T0);
             Assert.IsTrue(Vector3.Distance(vel, deriv) < 1e-4f);
+        }
+
+        private static CubicPHCurve3D CreateSampleCurve()
+        {
+            Vector3 A = new(1f, 0f, 0f);
+            Vector3 B = new(0f, 1f, 0f);
+            Vector3 C = new(0f, 0f, 1f);
+            Vector3 D = Vector3.Zero;
+            Vector3 E = Vector3.Zero;
+            return new CubicPHCurve3D(A, B, C, D, E);
+        }
+
+        private static float Curvature(Vector3 d1, Vector3 d2)
+        {
+            Vector3 cross = Vector3.Cross(d1, d2);
+            float len = d1.Length();
+            return cross.Length() / (len * len * len);
+        }
+
+        [TestMethod]
+        public void FitSegmentMatchesGivenTangents()
+        {
+            var reference = new CubicPHCurve3D(new Vector3(1f, 0f, 0f), new Vector3(0f, 1f, 0f), new Vector3(0f, 0f, 1f), Vector3.Zero, Vector3.Zero);
+
+            Vector3 p0 = reference.Position(0f);
+            Vector3 pMid = reference.Position(0.5f);
+            Vector3 p1 = reference.Position(1f);
+            Vector3 t0 = reference.Derivative(0f);
+            Vector3 tMid = reference.Derivative(0.5f);
+            Vector3 t1 = reference.Derivative(1f);
+            Vector3 n0 = reference.Normal(0f);
+            Vector3 nMid = reference.Normal(0.5f);
+            Vector3 n1 = reference.Normal(1f);
+            float k0 = Curvature(t0, reference.SecondDerivative(0f));
+            float kMid = Curvature(tMid, reference.SecondDerivative(0.5f));
+            float k1 = Curvature(t1, reference.SecondDerivative(1f));
+
+            var cps = new[]
+            {
+                new CubicPHCurve3DFitter.ControlPointEx{Position=p0, Tangent=t0, Time=0f, Normal=n0, Curvature=k0},
+                new CubicPHCurve3DFitter.ControlPointEx{Position=pMid, Tangent=tMid, Time=0.5f, Normal=nMid, Curvature=kMid},
+                new CubicPHCurve3DFitter.ControlPointEx{Position=p1, Tangent=t1, Time=1f, Normal=n1, Curvature=k1}
+            };
+
+            bool ok = CubicPHCurve3DFitter.FitSingleSegmentPH3D(cps, out var curve, out var posErr, out var normErr, out var T0, out var T1);
+            Assert.IsTrue(ok);
+            Assert.IsTrue(posErr < 1e-5f);
+            Assert.IsTrue(normErr < 1e-5f);
+            Assert.AreEqual(0f, T0, 1e-6f);
+            Assert.AreEqual(1f, T1, 1e-6f);
+            Assert.IsTrue(Vector3.Distance(curve.Derivative(0f), t0) < 1e-6f);
+            Assert.IsTrue(Vector3.Distance(curve.Derivative(1f), t1) < 1e-6f);
+
+            float midT = (T0 + T1) * 0.5f;
+            Vector3 vel = PHCurveTimeUtils.VelocityAtTime(curve, midT, T0, T1);
+            Vector3 deriv = curve.Derivative(0.5f) / (T1 - T0);
+            Assert.IsTrue(Vector3.Distance(vel, deriv) < 1e-4f);
+        }
+
+        private static CubicPHCurve3DFitter.ControlPointEx[] SampleCurve(int count)
+        {
+            var curve = CreateSampleCurve();
+            var cps = new CubicPHCurve3DFitter.ControlPointEx[count];
+            for (int i = 0; i < count; ++i)
+            {
+                float t = (float)i / (count - 1);
+                Vector3 d1 = curve.Derivative(t);
+                Vector3 d2 = curve.SecondDerivative(t);
+                cps[i] = new CubicPHCurve3DFitter.ControlPointEx
+                {
+                    Position = curve.Position(t),
+                    Time = t,
+                    Normal = curve.Normal(t),
+                    Curvature = Curvature(d1, d2)
+                };
+            }
+            return cps;
+        }
+
+        [TestMethod]
+        public void FitSegmentOnSampleCurve()
+        {
+            int[] counts = { 2, 3, 4, 5 };
+            foreach (int count in counts)
+            {
+                var cps = SampleCurve(count);
+
+                if (count == 2)
+                {
+                    Assert.ThrowsException<MaximumIterationsException>(() =>
+                        CubicPHCurve3DFitter.FitSingleSegmentPH3D(cps, out _, out _, out _, out _, out _));
+                    continue;
+                }
+
+                bool ok = CubicPHCurve3DFitter.FitSingleSegmentPH3D(cps,
+                    out var curve, out var posErr, out var normErr, out var T0, out var T1);
+
+                System.Console.WriteLine($"count={count} posErr={posErr} normErr={normErr}");
+                Assert.IsTrue(ok, $"fit failed for count {count}");
+                Assert.IsTrue(posErr < 0.1f, $"posErr too large for count {count}");
+                Assert.IsTrue(normErr < 1f, $"normErr too large for count {count}");
+                Assert.AreEqual(0f, T0, 1e-6f);
+                Assert.AreEqual(1f, T1, 1e-6f);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- merge upstream `main` into work branch
- include tangent-based fitting test alongside sample-curve tests
- keep algebraic tangent fitting in `CubicPHCurve3DFitter`

## Testing
- `dotnet test` *(fails: FitSegmentOnSampleCurve and FitSegmentProducesSmallErrors)*

------
https://chatgpt.com/codex/tasks/task_e_684b2d9ce400832a9f6cd17e2ab3f28f