### PR TITLE
Merge control point structures and add time utilities

### DIFF
--- a/PH-Curve.Test/CubicPHCurve3DFitterTests.cs
+++ b/PH-Curve.Test/CubicPHCurve3DFitterTests.cs
@@ -12,29 +12,29 @@ namespace PH_Curve.Test
         {
             var cps = new[]
             {
-                new CubicPHCurve3DFitter.ControlPointEx
+                new CubicPHCurve3D.ControlPoint
                 {
                     Position = new Vector3(0,0,0),
                     Tangent = new Vector3(2,2,0),
-                    Time = 0f,
                     Normal = Vector3.UnitZ,
-                    Curvature = 0f
+                    Curvature = 0f,
+                    Time = 0f
                 },
-                new CubicPHCurve3DFitter.ControlPointEx
+                new CubicPHCurve3D.ControlPoint
                 {
                     Position = new Vector3(1,1,0),
                     Tangent = new Vector3(0,0,0),
-                    Time = 0.5f,
                     Normal = Vector3.UnitZ,
-                    Curvature = 0f
+                    Curvature = 0f,
+                    Time = 0.5f
                 },
-                new CubicPHCurve3DFitter.ControlPointEx
+                new CubicPHCurve3D.ControlPoint
                 {
                     Position = new Vector3(2,0,0),
                     Tangent = new Vector3(2,-2,0),
-                    Time = 1f,
                     Normal = Vector3.UnitZ,
-                    Curvature = 0f
+                    Curvature = 0f,
+                    Time = 1f
                 }
             };
 
@@ -48,7 +48,7 @@ namespace PH_Curve.Test
 
             // check velocity utility
             float midT = (T0 + T1) * 0.5f;
-            Vector3 vel = PHCurveTimeUtils.VelocityAtTime(curve, midT, T0, T1);
+            Vector3 vel = curve.VelocityAtTime(midT, T0, T1);
             Vector3 deriv = curve.Derivative(0.5f) / (T1 - T0);
             Assert.IsTrue(Vector3.Distance(vel, deriv) < 1e-4f);
         }
@@ -91,9 +91,9 @@ namespace PH_Curve.Test
 
             var cps = new[]
             {
-                new CubicPHCurve3DFitter.ControlPointEx{Position=p0, Tangent=t0, Time=0f, Normal=n0, Curvature=k0},
-                new CubicPHCurve3DFitter.ControlPointEx{Position=pMid, Tangent=tMid, Time=0.5f, Normal=nMid, Curvature=kMid},
-                new CubicPHCurve3DFitter.ControlPointEx{Position=p1, Tangent=t1, Time=1f, Normal=n1, Curvature=k1}
+                new CubicPHCurve3D.ControlPoint{Position=p0, Tangent=t0, Normal=n0, Curvature=k0, Time=0f},
+                new CubicPHCurve3D.ControlPoint{Position=pMid, Tangent=tMid, Normal=nMid, Curvature=kMid, Time=0.5f},
+                new CubicPHCurve3D.ControlPoint{Position=p1, Tangent=t1, Normal=n1, Curvature=k1, Time=1f}
             };
 
             bool ok = CubicPHCurve3DFitter.FitSingleSegmentPH3D(cps, out var curve, out var posErr, out var normErr, out var T0, out var T1);
@@ -106,27 +106,27 @@ namespace PH_Curve.Test
             Assert.IsTrue(Vector3.Distance(curve.Derivative(1f), t1) < 1e-6f);
 
             float midT = (T0 + T1) * 0.5f;
-            Vector3 vel = PHCurveTimeUtils.VelocityAtTime(curve, midT, T0, T1);
+            Vector3 vel = curve.VelocityAtTime(midT, T0, T1);
             Vector3 deriv = curve.Derivative(0.5f) / (T1 - T0);
             Assert.IsTrue(Vector3.Distance(vel, deriv) < 1e-4f);
         }
 
-        private static CubicPHCurve3DFitter.ControlPointEx[] SampleCurve(int count)
+        private static CubicPHCurve3D.ControlPoint[] SampleCurve(int count)
         {
             var curve = CreateSampleCurve();
-            var cps = new CubicPHCurve3DFitter.ControlPointEx[count];
+            var cps = new CubicPHCurve3D.ControlPoint[count];
             for (int i = 0; i < count; ++i)
             {
                 float t = (float)i / (count - 1);
                 Vector3 d1 = curve.Derivative(t);
                 Vector3 d2 = curve.SecondDerivative(t);
-                cps[i] = new CubicPHCurve3DFitter.ControlPointEx
+                cps[i] = new CubicPHCurve3D.ControlPoint
                 {
                     Position = curve.Position(t),
                     Tangent = d1,
-                    Time = t,
                     Normal = curve.Normal(t),
-                    Curvature = Curvature(d1, d2)
+                    Curvature = Curvature(d1, d2),
+                    Time = t
                 };
             }
             return cps;

--- a/PH-Curve.Test/CubicPHCurve3DTests.cs
+++ b/PH-Curve.Test/CubicPHCurve3DTests.cs
@@ -110,6 +110,15 @@ namespace PH_Curve.Test
 
             Vector3 offset = curve.OffsetPoint(t, 1f);
             AssertVector(new Vector3(0f, 1f, 0f), offset, 1e-6f, "Offset point");
+
+            float curvature = curve.Curvature(t);
+            Assert.AreEqual(1f, curvature, 1e-6f, "Curvature at t=0");
+
+            Vector3 vel = curve.VelocityAtTime(t, 0f, 1f);
+            AssertVector(curve.Derivative(t), vel, 1e-6f, "Velocity at t=0");
+
+            float speedAbs = curve.SpeedAtTime(t, 0f, 1f);
+            Assert.AreEqual(speed, speedAbs, 1e-6f, "Speed at absolute time");
         }
     }
 }

--- a/PH-Curve/CubicPHCurve3DFitter.cs
+++ b/PH-Curve/CubicPHCurve3DFitter.cs
@@ -7,25 +7,9 @@ namespace CubicPHCurve
 {
     public class CubicPHCurve3DFitter
     {
-        /// <summary>
-        /// Control point used for fitting including time and normal information.
-        /// </summary>
-        public struct ControlPointEx
-        {
-            /// <summary>Spatial position of the point.</summary>
-            public Vector3 Position;
-            /// <summary>Tangent vector at the point.</summary>
-            public Vector3 Tangent;
-            /// <summary>Absolute time parameter of the point.</summary>
-            public float Time;
-            /// <summary>Normal vector at the point.</summary>
-            public Vector3 Normal;
-            /// <summary>Curvature at the point.</summary>
-            public float Curvature;
-        }
 
         public static bool FitSingleSegmentPH3D(
-            ControlPointEx[] cps,
+            CubicPHCurve3D.ControlPoint[] cps,
             out CubicPHCurve3D fitted,
             out float rmsPosError,
             out float rmsNormError,
@@ -79,22 +63,6 @@ namespace CubicPHCurve
             rmsNormError = (float)Math.Sqrt(sumNorm2 / N);
 
             return true;
-        }
-    }
-
-    public static class PHCurveTimeUtils
-    {
-        public static Vector3 VelocityAtTime(CubicPHCurve3D curve, float T, float T0, float T1)
-        {
-            float tParam = (T - T0) / (T1 - T0);
-            Vector3 dr_dtp = curve.Derivative(tParam);
-            float invDur = 1.0f / (T1 - T0);
-            return dr_dtp * invDur;
-        }
-
-        public static float SpeedAtTime(CubicPHCurve3D curve, float T, float T0, float T1)
-        {
-            return VelocityAtTime(curve, T, T0, T1).Length();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Vector3 position = curve.Position(0.5f);
 Vector3 tangent = curve.Tangent(0.5f);
 ```
 
-The above snippet creates a PH curve segment from two Hermite points and queries its midpoint position and tangent.
+The above snippet creates a PH curve segment from two Hermite points and queries its midpoint position and tangent. The `ControlPoint` struct also stores an optional absolute time value which can be used during curve fitting.
 


### PR DESCRIPTION
## Summary
- unify `ControlPoint` structures and include time information
- expose curvature and time‑based velocity helpers on `CubicPHCurve3D`
- adjust fitter and unit tests to use the new structure
- document new functionality in README

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684b3aa149c0832abac4681a76b8502e