### PR TITLE
Add segment timing fields

### DIFF
--- a/PHCurveLibrary.Test/PHCurve3DTests.cs
+++ b/PHCurveLibrary.Test/PHCurve3DTests.cs
@@ -25,7 +25,7 @@ namespace PHCurveLibrary.Tests
 
         private static PHCurve3D CreateParabola()
         {
-            return new PHCurve3D(A, B, C, D, E);
+            return new PHCurve3D(A, B, C, D, E, 0f, 1f);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace PHCurveLibrary.Tests
             Vector3 c = new(0f, 0f, 1f);
             Vector3 d = new(1f, 0f, 0f);
             Vector3 e = new(0f, 1f, 0f);
-            return new PHCurve3D(a, b, c, d, e);
+            return new PHCurve3D(a, b, c, d, e, 0f, 1f);
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace PHCurveLibrary.Tests
             Vector3 a = new(1f, 0f, 0f);
             Vector3 b = new(2f, 2f, 0f);
             Vector3 c = new(0f, 2f, 0f);
-            PHCurve3D curve = new(a, b, c, Vector3.Zero, Vector3.Zero);
+            PHCurve3D curve = new(a, b, c, Vector3.Zero, Vector3.Zero, 0f, 1f);
 
             float expected = 1f + 1f + 2f / 3f; // s(1)
             float length = curve.ArcLength(1f);
@@ -298,7 +298,7 @@ namespace PHCurveLibrary.Tests
         {
             HermiteControlPoint3D p0 = new(new Vector3(0, 0, 0), new Vector3(1, 0, 0), 0f, Vector3.UnitY);
             HermiteControlPoint3D p1 = new(new Vector3(1, 1, 0), new Vector3(0, 1, 0), 0f, Vector3.UnitY);
-            PHCurve3D curve = PHCurveFactory.CreateQuintic(p0, p1);
+            PHCurve3D curve = PHCurveFactory.CreateQuintic(p0, p1, 0f, 1f);
 
             float analytic = curve.ArcLength(1f);
             float numeric = NumericalArcLength(curve, 1f);
@@ -322,6 +322,28 @@ namespace PHCurveLibrary.Tests
 
             System.Console.WriteLine($"ArcLength_HigherOrderCurve_FallsBackToNumerical: analytic {analytic}, numeric {numeric}");
             Assert.AreEqual(numeric, analytic, 1e-4f);
+        }
+
+        /// <summary>
+        /// The StartTime and EndTime fields must be stored and allow mapping of
+        /// absolute time to the normalised parameter.
+        /// </summary>
+        [TestMethod]
+        public void StartAndEndTime_MapAbsoluteTime()
+        {
+            float start = 5f;
+            float end = 8f;
+            PHCurve3D curve = new(A, B, C, D, E, start, end);
+
+            Assert.AreEqual(start, curve.StartTime, 1e-6f);
+            Assert.AreEqual(end, curve.EndTime, 1e-6f);
+
+            float midTime = (start + end) / 2f;
+            float param = (midTime - curve.StartTime) / (curve.EndTime - curve.StartTime);
+            Vector3 expected = curve.Position(0.5f);
+            Vector3 actual = curve.Position(param);
+
+            AssertVector(expected, actual, 1e-6f, "Position at mid time");
         }
     }
 }

--- a/PHCurveLibrary.Test/PHCurveFactoryTests.cs
+++ b/PHCurveLibrary.Test/PHCurveFactoryTests.cs
@@ -30,7 +30,7 @@ namespace PHCurveLibrary.Tests
             HermiteControlPoint3D p0 = new(new Vector3(0, 0, 0), new Vector3(1, 0, 0), 0, new Vector3(0, 1, 0));
             HermiteControlPoint3D p1 = new(new Vector3(1, 1, 0), new Vector3(0, 1, 0), 0, new Vector3(-1, 0, 0));
 
-            PHCurve3D c = PHCurveFactory.CreateQuintic(p0, p1);
+            PHCurve3D c = PHCurveFactory.CreateQuintic(p0, p1, 0f, 1f);
 
             Console.WriteLine(
                 "QuinticG2Interpolation_MatchesHermite: Created curve from ({0}) to ({1}).",
@@ -60,7 +60,7 @@ namespace PHCurveLibrary.Tests
             // expression of r'(t). This verifies that the integration constants
             // in Position(t) are correct.
             HermiteControlPoint3D p = new(new Vector3(0, 0, 0), new Vector3(1, 2, 0), 0.1f, new Vector3(-2, 1, 0));
-            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p);
+            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p, 0f, 1f);
             Console.WriteLine(
                 "FiniteDifferenceDerivative_ApproximatesAnalytic: Start derivative comparison.");
             for (int i = 1; i < 10; i++)
@@ -83,7 +83,7 @@ namespace PHCurveLibrary.Tests
             // and serves as a basic sanity check for the Frenet frame
             // computation.
             HermiteControlPoint3D p = new(new Vector3(0, 0, 0), new Vector3(1, 0, 0), 0.5f, new Vector3(0, 1, 0));
-            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p);
+            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p, 0f, 1f);
             float d = 0.2f;
             Console.WriteLine("OffsetPoint_MaintainsDistance: Checking offset distance {0}.", d);
             for (int i = 0; i <= 5; i++)
@@ -105,7 +105,7 @@ namespace PHCurveLibrary.Tests
             // respect to t -> 1 - t.
             HermiteControlPoint3D p0 = new(new Vector3(0, 0, 0), new Vector3(1, 0, 0), 0, new Vector3(0, 1, 0));
             HermiteControlPoint3D p1 = new(new Vector3(2, 0, 0), new Vector3(1, 0, 0), 0, new Vector3(0, 1, 0));
-            PHCurve3D c = PHCurveFactory.CreateQuintic(p0, p1);
+            PHCurve3D c = PHCurveFactory.CreateQuintic(p0, p1, 0f, 1f);
             Console.WriteLine("Speed_IsMonotonicForStraightLine: Testing symmetry of speed.");
             for (int i = 0; i <= 5; i++)
             {
@@ -127,8 +127,8 @@ namespace PHCurveLibrary.Tests
             HermiteControlPoint3D a = new(Vector3.Zero, new Vector3(1, 0, 0), 0, new Vector3(0, 1, 0));
             HermiteControlPoint3D b = new(Vector3.Zero, new Vector3(0, 1, 0), 0, new Vector3(-1, 0, 0));
             HermiteControlPoint3D cPoint = new(Vector3.Zero, new Vector3(1, 0, 0), 0, new Vector3(0, -1, 0));
-            PHCurve3D c1 = PHCurveFactory.CreateQuintic(a, b);
-            PHCurve3D c2 = PHCurveFactory.CreateQuintic(b, cPoint);
+            PHCurve3D c1 = PHCurveFactory.CreateQuintic(a, b, 0f, 1f);
+            PHCurve3D c2 = PHCurveFactory.CreateQuintic(b, cPoint, 0f, 1f);
             Console.WriteLine("ValidateG2_BetweenSegments: Checking join between segments c1 and c2.");
             Assert.IsTrue(PHCurveFactory.ValidateG2(c1, c2));
             Console.WriteLine("ValidateG2_BetweenSegments: Segments pass G2 validation.");
@@ -141,7 +141,7 @@ namespace PHCurveLibrary.Tests
         public void TangentUnit_EqualsNormalizedDerivative()
         {
             HermiteControlPoint3D p = new(new Vector3(0, 0, 0), new Vector3(1, 0.5f, 0), 0.2f, new Vector3(0, 0, 1));
-            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p);
+            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p, 0f, 1f);
             Console.WriteLine(
                 "TangentUnit_EqualsNormalizedDerivative: Comparing tangent unit vector against derivative.");
             for (int i = 0; i <= 10; i++)
@@ -161,7 +161,7 @@ namespace PHCurveLibrary.Tests
         public void PrincipalNormal_IsUnitAndOrthogonal()
         {
             HermiteControlPoint3D p = new(new Vector3(0, 0, 0), new Vector3(1, 1, 0), 0.5f, Vector3.UnitZ);
-            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p);
+            PHCurve3D c = PHCurveFactory.CreateQuintic(p, p, 0f, 1f);
             Console.WriteLine("PrincipalNormal_IsUnitAndOrthogonal: Checking orthogonality and unit length.");
             for (int i = 1; i < 10; i++)
             {
@@ -183,8 +183,8 @@ namespace PHCurveLibrary.Tests
             HermiteControlPoint3D a = new(Vector3.Zero, Vector3.UnitX, 0, Vector3.UnitY);
             HermiteControlPoint3D b1 = new(Vector3.One, Vector3.UnitX, 0, Vector3.UnitY);
             HermiteControlPoint3D b2 = new(Vector3.One, Vector3.UnitX, 0, Vector3.UnitZ);
-            PHCurve3D c1 = PHCurveFactory.CreateQuintic(a, b1);
-            PHCurve3D c2 = PHCurveFactory.CreateQuintic(a, b2);
+            PHCurve3D c1 = PHCurveFactory.CreateQuintic(a, b1, 0f, 1f);
+            PHCurve3D c2 = PHCurveFactory.CreateQuintic(a, b2, 0f, 1f);
             Console.WriteLine("ValidateG2_FailsWhenNormalsDiffer: Comparing segments with different normals.");
             Assert.IsFalse(PHCurveFactory.ValidateG2(c1, c2));
             Console.WriteLine("ValidateG2_FailsWhenNormalsDiffer: Validation failed as expected.");
@@ -200,7 +200,7 @@ namespace PHCurveLibrary.Tests
         {
             HermiteControlPoint3D p0 = new(Vector3.Zero, new Vector3(2, 0, 0), 0f, Vector3.UnitY);
             HermiteControlPoint3D p1 = new(new Vector3(2, 0, 0), new Vector3(2, 0, 0), 0f, Vector3.UnitY);
-            PHCurve3D c = PHCurveFactory.CreateQuintic(p0, p1);
+            PHCurve3D c = PHCurveFactory.CreateQuintic(p0, p1, 0f, 1f);
 
             float length = NumericalArcLength(c);
             Console.WriteLine(
@@ -221,7 +221,7 @@ namespace PHCurveLibrary.Tests
                 new Vector3(0, 0, 0), new Vector3(1, 0, 0), 0.5f, new Vector3(0, 1, 0));
             HermiteControlPoint3D p1 = new(
                 new Vector3(1, 1, 0), new Vector3(0, 1, 0), -0.25f, new Vector3(-1, 0, 0));
-            PHCurve3D curve = PHCurveFactory.CreateQuintic(p0, p1);
+            PHCurve3D curve = PHCurveFactory.CreateQuintic(p0, p1, 0f, 1f);
 
             Console.WriteLine("SecondDerivative_ReflectsEndpointCurvature: verifying r''(0) and r''(1).");
 
@@ -233,6 +233,31 @@ namespace PHCurveLibrary.Tests
 
             Assert.IsTrue(Vector3.Distance(expected0, d0) < 1e-5f);
             Assert.IsTrue(Vector3.Distance(d1 - d0, expectedDelta) < 1e-5f);
+        }
+
+        /// <summary>
+        /// CreateQuintic must assign StartTime and EndTime correctly.
+        /// </summary>
+        [TestMethod]
+        public void CreateQuintic_AssignsTimeInterval()
+        {
+            HermiteControlPoint3D p0 = new(Vector3.Zero, Vector3.UnitX, 0f, Vector3.UnitY);
+            HermiteControlPoint3D p1 = new(Vector3.One, Vector3.UnitY, 0f, -Vector3.UnitX);
+
+            float start = 2f;
+            float end = 4f;
+
+            PHCurve3D curve = PHCurveFactory.CreateQuintic(p0, p1, start, end);
+
+            Assert.AreEqual(start, curve.StartTime, 1e-6f);
+            Assert.AreEqual(end, curve.EndTime, 1e-6f);
+
+            float mid = (start + end) / 2f;
+            float param = (mid - start) / (end - start);
+            Vector3 expected = curve.Position(0.5f);
+            Vector3 actual = curve.Position(param);
+
+            Assert.IsTrue(Vector3.Distance(expected, actual) < 1e-6f);
         }
 
         private static float NumericalArcLength(PHCurve3D c, int steps = 100)

--- a/PHCurveLibrary/PHCurve3D.cs
+++ b/PHCurveLibrary/PHCurve3D.cs
@@ -12,7 +12,9 @@ namespace PHCurveLibrary
     /// Represents a spatial quintic Pythagorean Hodograph (PH) curve. The
     /// derivative of the curve is a polynomial r'(t) = A + Bt + Ct² + Dt³ + Et´
     /// whose squared norm is itself a polynomial. This property enables exact
-    /// arc-length evaluation and simple offsetting.
+    /// arc-length evaluation and simple offsetting. Each instance also stores
+    /// the absolute time interval of the segment so that <c>t</c> can be
+    /// mapped to real time.
     /// </summary>
     public struct PHCurve3D
     {
@@ -32,15 +34,43 @@ namespace PHCurveLibrary
         public readonly Vector3 E;
 
         /// <summary>
-        /// Creates a PH curve from derivative coefficients.
+        /// Absolute start time of the segment. The parameter <c>t=0</c>
+        /// corresponds to this time value.
         /// </summary>
-        public PHCurve3D(Vector3 a, Vector3 b, Vector3 c, Vector3 d, Vector3 e)
+        public readonly float StartTime;
+
+        /// <summary>
+        /// Absolute end time of the segment. The parameter <c>t=1</c>
+        /// corresponds to this time value.
+        /// </summary>
+        public readonly float EndTime;
+
+        /// <summary>
+        /// Creates a PH curve from derivative coefficients and time interval.
+        /// </summary>
+        /// <param name="a">Constant hodograph term.</param>
+        /// <param name="b">Linear hodograph term.</param>
+        /// <param name="c">Quadratic hodograph term.</param>
+        /// <param name="d">Cubic hodograph term.</param>
+        /// <param name="e">Quartic hodograph term.</param>
+        /// <param name="startTime">Absolute start time of the segment.</param>
+        /// <param name="endTime">Absolute end time of the segment.</param>
+        public PHCurve3D(
+            Vector3 a,
+            Vector3 b,
+            Vector3 c,
+            Vector3 d,
+            Vector3 e,
+            float startTime,
+            float endTime)
         {
             A = a;
             B = b;
             C = c;
             D = d;
             E = e;
+            StartTime = startTime;
+            EndTime = endTime;
         }
 
         /// <summary>

--- a/PHCurveLibrary/PHCurveFactory.cs
+++ b/PHCurveLibrary/PHCurveFactory.cs
@@ -22,7 +22,13 @@ namespace PHCurveLibrary
         /// </summary>
         /// <param name="p0">Start Hermite control point.</param>
         /// <param name="p1">End Hermite control point.</param>
-        public static PHCurve3D CreateQuintic(HermiteControlPoint3D p0, HermiteControlPoint3D p1)
+        /// <param name="startTime">Absolute start time of the segment.</param>
+        /// <param name="endTime">Absolute end time of the segment.</param>
+        public static PHCurve3D CreateQuintic(
+            HermiteControlPoint3D p0,
+            HermiteControlPoint3D p1,
+            float startTime,
+            float endTime)
         {
             Vector3 A = p0.Tangent;
             Vector3 T1 = p1.Tangent;
@@ -50,7 +56,7 @@ namespace PHCurveLibrary
             Vector3 D = new(Coefs[1, 0], Coefs[1, 1], Coefs[1, 2]);
             Vector3 E = new(Coefs[2, 0], Coefs[2, 1], Coefs[2, 2]);
 
-            return new PHCurve3D(A, B, C, D, E);
+            return new PHCurve3D(A, B, C, D, E, startTime, endTime);
         }
 
         /// <summary>

--- a/PHCurveLibrary/PathPlanner.cs
+++ b/PHCurveLibrary/PathPlanner.cs
@@ -10,7 +10,7 @@ namespace PHCurveLibrary
     /// <summary>
     /// Builds a multi-segment path composed of <see cref="PHCurve3D"/> segments.
     /// Each segment is created from successive Hermite control points using
-    /// <see cref="PHCurveFactory.CreateQuintic(PHCurveLibrary.HermiteControlPoint3D, PHCurveLibrary.HermiteControlPoint3D)"/>.
+    /// <see cref="PHCurveFactory.CreateQuintic(PHCurveLibrary.HermiteControlPoint3D, PHCurveLibrary.HermiteControlPoint3D, float, float)"/>.
     /// </summary>
     public class PathPlanner
     {
@@ -23,7 +23,7 @@ namespace PHCurveLibrary
         /// <param name="end">End Hermite data.</param>
         public void AddSegment(HermiteControlPoint3D start, HermiteControlPoint3D end)
         {
-            PHCurve3D curve = PHCurveFactory.CreateQuintic(start, end);
+            PHCurve3D curve = PHCurveFactory.CreateQuintic(start, end, 0f, 1f);
             segments.Add(curve);
         }
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ using PHCurveLibrary;
 
 var p0 = new HermiteControlPoint3D(new Vector3(0,0,0), Vector3.UnitX, 0f, Vector3.UnitY);
 var p1 = new HermiteControlPoint3D(new Vector3(1,1,0), Vector3.UnitY, 0f, -Vector3.UnitX);
-PHCurve3D curve = PHCurveFactory.CreateQuintic(p0, p1);
+PHCurve3D curve = PHCurveFactory.CreateQuintic(p0, p1, 0f, 1f);
 
 Vector3 position = curve.Position(0.5f);
 Vector3 tangent = curve.TangentUnit(0.5f);


### PR DESCRIPTION
## Summary
- store start and end time on PHCurve3D
- expose timing parameters in PHCurveFactory.CreateQuintic
- update PathPlanner and tests for new parameters
- adjust documentation snippets
- test StartTime and EndTime handling in curve and factory

## Testing
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68502129cf40832a8c51146b3e161afc