### PR TITLE
Add homotopy method reference

### DIFF
--- a/INSTRUCTION_FITTING.md
+++ b/INSTRUCTION_FITTING.md
@@ -70,7 +70,7 @@ Each fitting agent is responsible for one algorithm and provides both fixed and 
 
 ## 4. Homotopy Continuation
 
-- **Reference:** [Albrecht & Farouki 1996](PHCurveLibrary/References/Schroecker_Sir_2023_Optimal_Interpolation_with_Spatial_Rational_PH_Curves.pdf)
+- **Reference:** [Albrecht & Farouki 1996](PHCurveLibrary/References/Fitting/Farouki_Albrecht_1996_C2_PH%20Curve_homotopy_methode.pdf)
 - **Idea:** Start from a simple curve and deform it via a homotopy parameter towards the final solution while keeping G² conditions.
 - **Advantages:**
   - Avoids abrupt changes and can follow multiple valid solutions.

--- a/PHCurveLibrary/References/Fitting/SUMMARY.DE.md
+++ b/PHCurveLibrary/References/Fitting/SUMMARY.DE.md
@@ -64,6 +64,7 @@ Diese Eigenschaften machen PH-Kurven ideal für CNC-Interpolation, Bewegungssteu
 - Verbindung einer einfachen Ausgangskurve mit Zielkurve
 - Sicherstellung \( C^2 \)-Stetigkeit zwischen PH-Segmenten
 - Lösung komplexer Interpolationsprobleme auf globaler Ebene
+- PDF-Link: [Local PDF](Fitting/Farouki_Albrecht_1996_C2_PH%20Curve_homotopy_methode.pdf)
 
 ### 5. Theorie und neuere Entwicklungen
 - **Weierstraß-Theorem** für PH-Kurven (Choi & Moon 2008): beliebig gute Approximation
@@ -98,6 +99,7 @@ Trotz der höheren Komplexität im Vergleich zu klassischen Splines haben sich P
  - Pastva 1998: *Bezier Curve Fitting* [Local PDF](Pastva_1998_Bezier_Curve_Fitting.pdf)
  - Farouki: *Computer Numerical Control Algorithms* [Local PDF](Farouki_Computer_numerical_control_algorithms.pdf)
 - Farouki 2008: *Pythagorean-Hodograph Curves: Algebra and Geometry Inseparable* (Buch)
+- Albrecht & Farouki 1996: *C²-PH-Splines per Homotopie* [Local PDF](Fitting/Farouki_Albrecht_1996_C2_PH%20Curve_homotopy_methode.pdf)
 
 Gib mir Bescheid, wenn du eine Implementierung, Grafiken oder eine LaTeX/PDF-Version benötigst.
 

--- a/PHCurveLibrary/References/Fitting/SUMMARY.md
+++ b/PHCurveLibrary/References/Fitting/SUMMARY.md
@@ -64,6 +64,7 @@ These features make PH curves ideal for CNC interpolation, motion control, and p
 - Connect simple initial curve to desired target
 - Ensure \( C^2 \) continuity across PH segments
 - Solve complex interpolation problems globally
+- PDF link: [Local PDF](Fitting/Farouki_Albrecht_1996_C2_PH%20Curve_homotopy_methode.pdf)
 
 ### 5. Theoretical and Recent Advances
 - **Weierstrass-type theorem** for PH curves (Choi & Moon 2008): they can approximate any smooth path
@@ -98,6 +99,7 @@ While more complex than traditional splines, PH curve fitting methods have matur
  - Pastva 1998: *Bezier Curve Fitting* [Local PDF](Pastva_1998_Bezier_Curve_Fitting.pdf)
  - Farouki: *Computer Numerical Control Algorithms* [Local PDF](Farouki_Computer_numerical_control_algorithms.pdf)
 - Farouki 2008: *Pythagorean-Hodograph Curves: Algebra and Geometry Inseparable* (book)
+- Albrecht & Farouki 1996: *C² PH Splines via Homotopy* [Local PDF](Fitting/Farouki_Albrecht_1996_C2_PH%20Curve_homotopy_methode.pdf)
 
 Let me know if you'd like code implementations or tutorials for any of these methods.
 

--- a/PHCurveLibrary/References/SUMMARY.DE.md
+++ b/PHCurveLibrary/References/SUMMARY.DE.md
@@ -26,6 +26,9 @@ Die Arbeit **Global well-posedness of strong solutions to the 3D primitive equat
 ## 8. Arrizabalaga et al. (2024)
 **PHODCOS: Pythagorean Hodograph-based Differentiable Coordinate System** ([Lokale PDF](Arrizabalaga_et_al_2024_PHODCOS.pdf)) beschreibt ein differenzierbares Koordinatensystem entlang einer Kurve, das mittels PH-Kurven exakte Ableitungen liefert und damit präzise robotische Navigation ermöglicht.
 
+## 9. Albrecht & Farouki (1996)
+**Construction of C² Pythagorean-hodograph interpolating splines by the homotopy method** ([Lokale PDF](Fitting/Farouki_Albrecht_1996_C2_PH%20Curve_homotopy_methode.pdf)) stellt eine Homotopie-Methode vor, mit der alle C²-PH-Quintiksplines berechnet werden, die vorgegebene Punkte interpolieren. Durch Bewertung der Biegeenergie wird eine besonders glatte Lösung ausgewählt, deren Offsets rational und deren Bogenlänge polynomiell sind.
+
 ## Bezug zur Implementierung
 Unsere Bibliothek setzt viele dieser Konzepte um:
 - `PHCurve3D` stellt ein Quintik-Segment über die Hodograph-Koeffizienten A–E dar und liefert Position, Ableitungen, Geschwindigkeit und Bogenlänge.

--- a/PHCurveLibrary/References/SUMMARY.md
+++ b/PHCurveLibrary/References/SUMMARY.md
@@ -28,6 +28,9 @@ The paper titled **Global well-posedness of strong solutions to the 3D primitive
 ## 8. Arrizabalaga et al. (2024)
 **PHODCOS: Pythagorean Hodograph-based Differentiable Coordinate System** ([Local PDF](Arrizabalaga_et_al_2024_PHODCOS.pdf)) ([source](https://github.com/jonarriza96/phodcos))  introduces a differentiable moving frame defined via PH curves, providing exact derivatives for advanced robotic guidance.
 
+## 9. Albrecht & Farouki (1996)
+**Construction of C² Pythagorean-hodograph interpolating splines by the homotopy method** ([Local PDF](Fitting/Farouki_Albrecht_1996_C2_PH%20Curve_homotopy_methode.pdf)) presents a homotopy continuation approach to compute all PH quintic splines that satisfy C² conditions for given data points. The resulting curves offer smoother bending energy than ordinary cubics and yield rational offsets with polynomial arc length.
+
 ## Relation to the Implementation
 The `PHCurveLibrary` project mirrors many concepts from the literature:
 - `PHCurve3D` represents a quintic PH segment defined by its hodograph coefficients A–E and offers methods for position, derivatives, speed and arc length. It also computes Frenet-frame vectors.


### PR DESCRIPTION
## Summary
- integrate the 1996 homotopy method paper in reference summaries
- fix reference link in `INSTRUCTION_FITTING.md`
- list the new paper in recommended reading

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685149067870832a930dfee8c16bb8db