### PR TITLE
Fix segment position handling

### DIFF
--- a/PHCurveLibrary/Fitting/EvolutionFitter.cs
+++ b/PHCurveLibrary/Fitting/EvolutionFitter.cs
@@ -183,7 +183,9 @@ namespace PHCurveLibrary.Fitting
             {
                 PHCurve3D seg = FindSegment(segs, p.Time);
                 float u = (p.Time - seg.StartTime) / (seg.EndTime - seg.StartTime);
-                Vector3 curvePos = seg.Position(u);
+                int idx = reference.FindIndex(pt => Math.Abs(pt.Time - seg.StartTime) < 1e-6f);
+                Vector3 origin = idx >= 0 ? reference[idx].Position : Vector3.Zero;
+                Vector3 curvePos = seg.Position(u) + origin;
                 float d = Vector3.Distance(curvePos, p.Position);
                 if (d > maxPos)
                 {

--- a/PHCurveLibrary/Fitting/HeuristicFitter.cs
+++ b/PHCurveLibrary/Fitting/HeuristicFitter.cs
@@ -76,8 +76,9 @@ namespace PHCurveLibrary.Fitting
                 }
 
                 float segDuration = pts[end].Time - pts[start].Time;
-                HermiteControlPoint3D h0 = BuildHermitePoint(pts, ups, start, segDuration);
-                HermiteControlPoint3D h1 = BuildHermitePoint(pts, ups, end, segDuration);
+                Vector3 origin = pts[start].Position;
+                HermiteControlPoint3D h0 = BuildHermitePoint(pts, ups, start, segDuration, origin);
+                HermiteControlPoint3D h1 = BuildHermitePoint(pts, ups, end, segDuration, origin);
                 PHCurve3D seg = PHCurveFactory.CreateQuintic(h0, h1, pts[start].Time, pts[end].Time);
 
                 if (prevSeg.HasValue)
@@ -107,7 +108,8 @@ namespace PHCurveLibrary.Fitting
             List<PointData> pts,
             Vector3[] ups,
             int index,
-            float scale)
+            float scale,
+            Vector3 origin)
         {
             Vector3 tangent;
             float dt;
@@ -152,7 +154,7 @@ namespace PHCurveLibrary.Fitting
 
             normal = Vector3.Normalize(normal);
 
-            return new HermiteControlPoint3D(pts[index].Position, tangent, curvature, normal);
+            return new HermiteControlPoint3D(pts[index].Position - origin, tangent, curvature, normal);
         }
 
         private static Vector3[] PrepareUpVectors(List<PointData> pts)
@@ -186,7 +188,7 @@ namespace PHCurveLibrary.Fitting
             }
 
             HermiteControlPoint3D start = new(
-                previous.Position(1f),
+                Vector3.Zero,
                 previous.TangentUnit(1f),
                 previous.Curvature(1f),
                 previous.PrincipalNormal(1f));

--- a/PHCurveLibrary/Fitting/HomotopyFitter.cs
+++ b/PHCurveLibrary/Fitting/HomotopyFitter.cs
@@ -122,8 +122,9 @@ namespace PHCurveLibrary.Fitting
             float oriTol)
         {
             float segDuration = pts[end].Time - pts[start].Time;
-            HermiteControlPoint3D finalStart = BuildHermitePoint(pts, ups, start, segDuration);
-            HermiteControlPoint3D finalEnd = BuildHermitePoint(pts, ups, end, segDuration);
+            Vector3 origin = pts[start].Position;
+            HermiteControlPoint3D finalStart = BuildHermitePoint(pts, ups, start, segDuration, origin);
+            HermiteControlPoint3D finalEnd = BuildHermitePoint(pts, ups, end, segDuration, origin);
 
             Vector3 baseTangent = Vector3.Normalize(pts[end].Position - pts[start].Position);
             HermiteControlPoint3D baseStart = new(
@@ -150,7 +151,7 @@ namespace PHCurveLibrary.Fitting
                 HermiteControlPoint3D s = Interpolate(baseStart, finalStart, target);
                 HermiteControlPoint3D e = Interpolate(baseEnd, finalEnd, target);
                 PHCurve3D candidate = PHCurveFactory.CreateQuintic(s, e, t0, t1);
-                float posErr = ComputeMaxDeviation(candidate, pts, start, end, out float oriErr);
+                float posErr = ComputeMaxDeviation(candidate, pts, start, end, out float oriErr, origin);
 
                 if (posErr <= posTol && oriErr <= oriTol)
                 {
@@ -168,7 +169,7 @@ namespace PHCurveLibrary.Fitting
                         HermiteControlPoint3D ms = Interpolate(baseStart, finalStart, mid);
                         HermiteControlPoint3D me = Interpolate(baseEnd, finalEnd, mid);
                         PHCurve3D test = PHCurveFactory.CreateQuintic(ms, me, t0, t1);
-                        float pErr = ComputeMaxDeviation(test, pts, start, end, out float oErr);
+                        float pErr = ComputeMaxDeviation(test, pts, start, end, out float oErr, origin);
                         if (pErr <= posTol && oErr <= oriTol)
                         {
                             seg = test;
@@ -190,7 +191,7 @@ namespace PHCurveLibrary.Fitting
                 }
             }
 
-            float finalPos = ComputeMaxDeviation(seg, pts, start, end, out float finalOri);
+            float finalPos = ComputeMaxDeviation(seg, pts, start, end, out float finalOri, origin);
             if (finalPos <= posTol && finalOri <= oriTol)
             {
                 return seg;
@@ -218,7 +219,7 @@ namespace PHCurveLibrary.Fitting
             }
 
             HermiteControlPoint3D start = new(
-                previous.Position(1f),
+                Vector3.Zero,
                 previous.TangentUnit(1f),
                 previous.Curvature(1f),
                 previous.PrincipalNormal(1f));
@@ -236,7 +237,8 @@ namespace PHCurveLibrary.Fitting
             List<PointData> pts,
             Vector3[] ups,
             int index,
-            float scale)
+            float scale,
+            Vector3 origin)
         {
             Vector3 tangent;
             float dt;
@@ -281,7 +283,7 @@ namespace PHCurveLibrary.Fitting
 
             normal = Vector3.Normalize(normal);
 
-            return new HermiteControlPoint3D(pts[index].Position, tangent, curvature, normal);
+            return new HermiteControlPoint3D(pts[index].Position - origin, tangent, curvature, normal);
         }
 
         private static Vector3[] PrepareUpVectors(List<PointData> pts)
@@ -312,7 +314,8 @@ namespace PHCurveLibrary.Fitting
             List<PointData> pts,
             int startIdx,
             int endIdx,
-            out float maxOri)
+            out float maxOri,
+            Vector3 origin)
         {
             float maxPos = 0f;
             maxOri = 0f;
@@ -338,7 +341,7 @@ namespace PHCurveLibrary.Fitting
                 }
                 Vector3 expected = pts[idx].Position;
 
-                Vector3 pos = seg.Position(u);
+                Vector3 pos = seg.Position(u) + origin;
                 float d = Vector3.Distance(pos, expected);
                 if (d > maxPos)
                 {

--- a/PHCurveLibrary/Fitting/LeastSquaresFitter.cs
+++ b/PHCurveLibrary/Fitting/LeastSquaresFitter.cs
@@ -64,11 +64,12 @@ namespace PHCurveLibrary.Fitting
                 float bestErr = float.MaxValue;
                 PHCurve3D bestSeg = default;
 
+                Vector3 origin = pts[start].Position;
                 for (int end = start + 1; end < pts.Count; ++end)
                 {
-                    PHCurve3D seg = BuildSegment(pts, ups, start, end);
+                    PHCurve3D seg = BuildSegment(pts, ups, start, end, origin);
 
-                    float posErr = ComputeMaxDeviation(seg, pts, start, end, out float oriErr);
+                    float posErr = ComputeMaxDeviation(seg, pts, start, end, out float oriErr, origin);
                     float worst = MathF.Max(posErr / posTol, oriErr / MathF.Max(oriTol, 1e-6f));
 
                     if (worst <= 1f)
@@ -117,7 +118,8 @@ namespace PHCurveLibrary.Fitting
             List<PointData> pts,
             Vector3[] ups,
             int start,
-            int end)
+            int end,
+            Vector3 origin)
         {
             Vector3 dir0 = Vector3.Normalize(TangentDirection(pts, start, true));
             Vector3 dir1 = Vector3.Normalize(TangentDirection(pts, end, false));
@@ -161,8 +163,8 @@ namespace PHCurveLibrary.Fitting
             Vector3 n0 = ComputeNormal(dir0, ups[start]);
             Vector3 n1 = ComputeNormal(dir1, ups[end]);
 
-            HermiteControlPoint3D h0 = new(pts[start].Position, dir0 * len0, curv0, n0);
-            HermiteControlPoint3D h1 = new(pts[end].Position, dir1 * len1, curv1, n1);
+            HermiteControlPoint3D h0 = new(pts[start].Position - origin, dir0 * len0, curv0, n0);
+            HermiteControlPoint3D h1 = new(pts[end].Position - origin, dir1 * len1, curv1, n1);
 
             return PHCurveFactory.CreateQuintic(h0, h1, pts[start].Time, pts[end].Time);
         }
@@ -271,7 +273,8 @@ namespace PHCurveLibrary.Fitting
             List<PointData> pts,
             int startIdx,
             int endIdx,
-            out float maxOri)
+            out float maxOri,
+            Vector3 origin)
         {
             float maxPos = 0f;
             maxOri = 0f;
@@ -286,7 +289,7 @@ namespace PHCurveLibrary.Fitting
             for (int i = startIdx; i <= endIdx; ++i)
             {
                 float u = (pts[i].Time - t0) / dt;
-                Vector3 pos = seg.Position(u);
+                Vector3 pos = seg.Position(u) + origin;
                 float d = Vector3.Distance(pos, pts[i].Position);
                 if (d > maxPos)
                 {
@@ -316,7 +319,7 @@ namespace PHCurveLibrary.Fitting
             }
 
             HermiteControlPoint3D start = new(
-                previous.Position(1f),
+                Vector3.Zero,
                 previous.TangentUnit(1f),
                 previous.Curvature(1f),
                 previous.PrincipalNormal(1f));

--- a/PHCurveLibrary/Fitting/LocalHermiteFitter.cs
+++ b/PHCurveLibrary/Fitting/LocalHermiteFitter.cs
@@ -61,11 +61,12 @@ namespace PHCurveLibrary.Fitting
                 float bestErr = float.MaxValue;
                 PHCurve3D bestSeg = default;
 
+                Vector3 origin = pts[start].Position;
                 for (int end = start + 1; end < pts.Count; ++end)
                 {
                     float segDuration = pts[end].Time - pts[start].Time;
-                    HermiteControlPoint3D h0 = BuildHermitePoint(pts, ups, start, segDuration);
-                    HermiteControlPoint3D h1 = BuildHermitePoint(pts, ups, end, segDuration);
+                    HermiteControlPoint3D h0 = BuildHermitePoint(pts, ups, start, segDuration, origin);
+                    HermiteControlPoint3D h1 = BuildHermitePoint(pts, ups, end, segDuration, origin);
 
                     PHCurve3D seg = PHCurveFactory.CreateQuintic(
                         h0,
@@ -73,7 +74,7 @@ namespace PHCurveLibrary.Fitting
                         pts[start].Time,
                         pts[end].Time);
 
-                    float posErr = ComputeMaxDeviation(seg, pts, start, end, out float oriErr);
+                    float posErr = ComputeMaxDeviation(seg, pts, start, end, out float oriErr, origin);
                     float worst = MathF.Max(posErr / posTol, oriErr / MathF.Max(oriTol, 1e-6f));
 
                     if (worst <= 1f)
@@ -126,7 +127,7 @@ namespace PHCurveLibrary.Fitting
             }
 
             HermiteControlPoint3D start = new(
-                previous.Position(1f),
+                Vector3.Zero,
                 previous.TangentUnit(1f),
                 previous.Curvature(1f),
                 previous.PrincipalNormal(1f));
@@ -144,7 +145,8 @@ namespace PHCurveLibrary.Fitting
             List<PointData> pts,
             Vector3[] ups,
             int index,
-            float scale)
+            float scale,
+            Vector3 origin)
         {
             Vector3 tangent;
             float dt;
@@ -189,7 +191,7 @@ namespace PHCurveLibrary.Fitting
 
             normal = Vector3.Normalize(normal);
 
-            return new HermiteControlPoint3D(pts[index].Position, tangent, curvature, normal);
+            return new HermiteControlPoint3D(pts[index].Position - origin, tangent, curvature, normal);
         }
 
         private static Vector3[] PrepareUpVectors(List<PointData> pts)
@@ -220,7 +222,8 @@ namespace PHCurveLibrary.Fitting
             List<PointData> pts,
             int startIdx,
             int endIdx,
-            out float maxOri)
+            out float maxOri,
+            Vector3 origin)
         {
             float maxPos = 0f;
             maxOri = 0f;
@@ -235,7 +238,7 @@ namespace PHCurveLibrary.Fitting
             for (int i = startIdx; i <= endIdx; ++i)
             {
                 float u = (pts[i].Time - t0) / dt;
-                Vector3 pos = seg.Position(u);
+                Vector3 pos = seg.Position(u) + origin;
                 float d = Vector3.Distance(pos, pts[i].Position);
                 if (d > maxPos)
                 {


### PR DESCRIPTION
## Summary
- correct segment origin handling for fitter algorithms
- adjust optimization joins with relative coordinates

## Testing
- `dotnet build PHCurveLibrary.sln -v q`
- `dotnet test PHCurveLibrary.sln --no-build -v q`

------
https://chatgpt.com/codex/tasks/task_e_6851820a72f8832a9ca85a489cd11a22