### PR TITLE
Fix LeastSquaresFitter subdivision

### DIFF
--- a/PHCurveLibrary/Fitting/LeastSquaresFitter.cs
+++ b/PHCurveLibrary/Fitting/LeastSquaresFitter.cs
@@ -179,6 +179,12 @@ namespace PHCurveLibrary.Fitting
             }
             else
             {
+                if (m <= 2)
+                {
+                    // No interior samples to split at; fallback to straight-line segments
+                    return FallbackPolyline(pts);
+                }
+
                 // Subdivide at the point of maximum error (avoid splitting at endpoints)
                 worstIdx = Math.Clamp(worstIdx, 1, m - 2);
                 var leftPts = pts.GetRange(0, worstIdx + 1);


### PR DESCRIPTION
## Summary
- prevent `LeastSquaresFitter` from throwing when only two points are available

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68528b37b104832a9795addc1fb217b0